### PR TITLE
Add Golang version of hd-idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-test/config
-*.tgz
+test/**/config

--- a/README.md
+++ b/README.md
@@ -1,9 +1,35 @@
 # docker-hd-idle
 
+<p>
+  <a href="https://hub.docker.com/r/tekgator/docker-hd-idle/tags?page=1&ordering=last_updated" alt="DockerBuildStatus">
+    <img src="https://img.shields.io/docker/cloud/build/tekgator/docker-hd-idle?style=for-the-badge" />
+  </a>
+  <a href="https://hub.docker.com/r/tekgator/docker-hd-idle" alt="DockerPulls">
+    <img src="https://img.shields.io/docker/pulls/tekgator/docker-hd-idle?style=for-the-badge" />
+  </a>
+  <a href="https://hub.docker.com/r/tekgator/docker-hd-idle/tags?page=1&ordering=last_updated" alt="DockerBuilds">
+    <img src="https://img.shields.io/docker/cloud/automated/tekgator/docker-hd-idle?style=for-the-badge" />
+  </a>
+  <a href="https://hub.docker.com/r/tekgator/docker-hd-idle/tags?page=1&ordering=last_updated" alt="DockerBuildStatus">
+    <img src="https://img.shields.io/docker/image-size/tekgator/docker-hd-idle/latest?style=for-the-badge" />
+  </a>
+  <a href="https://github.com/tekgator/docker-hd-idle/blob/main/LICENSE" alt="License">
+    <img src="https://img.shields.io/github/license/tekgator/docker-hd-idle?style=for-the-badge" />
+  </a>
+  <a href="https://github.com/tekgator/docker-hd-idle/releases" alt="Releases">
+    <img src="https://img.shields.io/github/v/release/tekgator/docker-hd-idle?style=for-the-badge" />
+  </a>
+</p>
+
 Bundle `hd-idle` application to run in a docker environment.
 
 - Maintained by [Patrick Weiss](https://github.com/tekgator)
 - Problems and issues can be filed on the [Github repository](https://github.com/tekgator/docker-hd-idle/issues)
+
+## buy-me-a-coffee
+Like some of my work? Buy me a coffee ☕ (or more likely a beer 🍺, or even more likly shoes 👠 or purse 👜 for the wify 😄)
+
+<a href="https://www.buymeacoffee.com/tekgator" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Many thanks to to both of them for this great tool!
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`1.2.0`, `latest`](https://github.com/tekgator/docker-hd-idle/blob/main/hd-idle/Dockerfile):  Golang version 1.13 and legacy version 1.05
+* [`1.2.0`, `latest`](https://github.com/tekgator/docker-hd-idle/blob/main/Dockerfile):  Golang version 1.13 and legacy version 1.05
+
+* [`dev`](https://github.com/tekgator/docker-hd-idle/blob/main/Dockerfile): Development build
 
 ## Word of cautions
 
@@ -101,7 +103,7 @@ docker run -d \
 
 ## Use with docker-compose
 
-A [sample](docker-compose.yml) docker-compose file can be found within the repository. Also the [test cases](hd-idle/test) are worth a look.
+A [sample](docker-compose.yml) docker-compose file can be found within the repository. Also the [test cases](test) are worth a look.
 
 ```yml
   hd-idle:

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -6,9 +6,7 @@ if [ ! -f ./hd-idle.config ]; then
     
     HD_IDLE_OPTS=
 
-    if [ ! -z "$IDLE_TIME" ]; then
-        HD_IDLE_OPTS="$HD_IDLE_OPTS -i $IDLE_TIME"
-    fi
+    [ ! -z "$IDLE_TIME" ] && HD_IDLE_OPTS="$HD_IDLE_OPTS -i $IDLE_TIME"
 
     for (( i=1 ; ; i++ )); do
         n="DISK_ID${i}"
@@ -20,6 +18,11 @@ if [ ! -f ./hd-idle.config ]; then
         IDLE_TIMEX=${IDLE_TIMEX:-600}
 
         HD_IDLE_OPTS="$HD_IDLE_OPTS -a $DISK_IDX -i $IDLE_TIMEX"
+
+        o="DISK_CMD${i}"
+        declare -n DISK_CMDX="$o"
+
+        [ ! -z "$DISK_CMDX" ] && HD_IDLE_OPTS="$HD_IDLE_OPTS -c ${DISK_CMDX,,}"
     done
 
     HD_IDLE_OPTS=${HD_IDLE_OPTS## } # remove leading spaces
@@ -49,5 +52,13 @@ source ./hd-idle.config
 
 echo "Run hd-idle with options:"
 echo "HD_IDLE_OPTS=$HD_IDLE_OPTS"
-echo
-hd-idle -d $HD_IDLE_OPTS
+
+if [[ "$LEGACY" == "1" ]]; then
+    echo "Running legacy version of hd-idle: http://hd-idle.sourceforge.net/"
+    echo
+    hd-idle.legacy -d $HD_IDLE_OPTS
+else
+    echo "Running golang version of hd-idle: https://github.com/adelolmo/hd-idle"
+    echo
+    hd-idle -d $HD_IDLE_OPTS
+fi

--- a/app/hd-idle.config
+++ b/app/hd-idle.config
@@ -1,6 +1,4 @@
-# hd-idle options
-#
-# Options are:
+# hd-idle options:
 #  -a <name>               Set device name of disks for subsequent idle-time
 #                          parameters (-i). This parameter is optional in the
 #                          sense that there's a default entry for all disks
@@ -8,7 +6,22 @@
 #                          parameter. This can also be a symlink
 #                          (e.g. /dev/disk/by-uuid/...)
 #  -i <idle_time>          Idle time in seconds.
-
-#HD_IDLE_OPTS="-i 180" = Set all disk in standby after 180 seconds inactivity
-#HD_IDLE_OPTS="-i 0 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711 -i 300" = Set no disks in stand by at all with the exception of the disk specified with idle time of 300 seconds
-#HD_IDLE_OPTS="-i 0 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711 -i 300 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4712 -i 600"
+#
+#
+# Only for Golang version:
+#
+#  -c <command_type>       Api call to stop the device. Possible values are "scsi"
+#                          (default value) and "ata".
+#  -s symlink_policy       Set the policy to resolve symlinks for devices.
+#                          If set to "0", symlinks are resolve only on start.
+#                          If set to "1", symlinks are also resolved on runtime
+#                          until success. By default symlinks are only resolve on start.
+#                          If the symlink doesn't resolve to a device, the default
+#                          configuration will be applied.
+#
+# Example 1: HD_IDLE_OPTS="-i 180" = Set all disk in standby after 180 seconds inactivity
+#
+# Example 2: HD_IDLE_OPTS="-i 0 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711 -i 300" = Set no disks in stand by at all with the exception of the disk specified with idle time of 300 seconds
+#
+# Example 3: HD_IDLE_OPTS="-i 0 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711 -i 300 -a /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4712 -i 600"
+#

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,11 @@ services:
     container_name: hd-idle
     privileged: true
     environment:
+      # LEGACY: 1    #uncomment to use legacy version of hd-idle
       IDLE_TIME: 0
       DISK_ID1: /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711
       IDLE_TIME1: 900
+      # DISK_CMD1: ata
       DISK_ID2: /dev/disk/by-uuid/fa376393-91e4-4d9f-8914-4712
       IDLE_TIME2: 1800
     volumes:

--- a/test/with_config/docker-compose.yml
+++ b/test/with_config/docker-compose.yml
@@ -3,9 +3,11 @@ version: "3"
 services:
 
   hd-idle:
-    build: ..
+    build: ../..
     container_name: hd-idle
     privileged: true
+    environment:
+      # LEGACY: 1    #uncomment to use legacy version of hd-idle
     volumes:
       - /dev:/dev
       - ./config:/config

--- a/test/with_env/docker-compose.yml
+++ b/test/with_env/docker-compose.yml
@@ -3,13 +3,15 @@ version: "3"
 services:
 
   hd-idle:
-    build: ..
+    build: ../..
     container_name: hd-idle
     privileged: true
     environment:
+      # LEGACY: 1    #uncomment to use legacy version of hd-idle
       IDLE_TIME: 0
       DISK_ID1: /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711
       IDLE_TIME1: 30
+      # DISK_CMD1: ata
       DISK_ID2: /dev/disk/by-uuid/fa376393-91e4-4d9f-8914-4712
       IDLE_TIME2: 60
     volumes:

--- a/test/with_env_and_config/docker-compose.yml
+++ b/test/with_env_and_config/docker-compose.yml
@@ -3,15 +3,17 @@ version: "3"
 services:
 
   hd-idle:
-    build: ..
+    build: ../..
     container_name: hd-idle
     privileged: true
     environment:
+      # LEGACY: 1    #uncomment to use legacy version of hd-idle
       IDLE_TIME: 0
       DISK_ID1: /dev/disk/by-uuid/994dffb1-96f0-4440-9ee1-4711
       IDLE_TIME1: 30
       DISK_ID2: /dev/disk/by-uuid/fa376393-91e4-4d9f-8914-4712
       IDLE_TIME2: 60
+      # DISK_CMD2: scsi
     volumes:
       - /dev:/dev
       - ./config:/config


### PR DESCRIPTION
The Golang version of [hd-idle](https://github.com/adelolmo/hd-idle) from [adelolmo](https://github.com/adelolmo) has been added as the default version for this docker image. The old legacy version of [hd-idle](http://hd-idle.sourceforge.net/) from [Christina Mueller](https://sourceforge.net/u/cjmueller/profile/) still remains in the image for backwards compatibility. It can be accessed by setting the environment variable `LEGACY=1`.